### PR TITLE
Allow options for serializer

### DIFF
--- a/lib/upfluence/endpoint/api_endpoint.rb
+++ b/lib/upfluence/endpoint/api_endpoint.rb
@@ -35,7 +35,7 @@ module Upfluence
                      elsif resource.respond_to?(:serialize)
                        resource.serialize.to_json
                      else
-                       ActiveModel::Serializer.serializer_for(resource).new(resource).to_json
+                       ActiveModel::Serializer.serializer_for(resource).new(resource, *args).to_json
                      end
           end
           halt [status, result] || 404


### PR DESCRIPTION
The idea behind is to allow us to use serializer options like `except` which we can for array of objects to serialize but not for object alone.