### PR TITLE
Not raise error on sentry limit exceeded

### DIFF
--- a/lib/upfluence/error_logger/sentry.rb
+++ b/lib/upfluence/error_logger/sentry.rb
@@ -20,11 +20,15 @@ module Upfluence
       end
 
       def notify(error, method, *args)
-        Raven.capture_exception(
-          error,
-          extra: { method: method, arguments: args },
-          tags: { method: method }
-        )
+        begin
+          Raven.capture_exception(
+            error,
+            extra: { method: method, arguments: args },
+            tags: { method: method }
+          )
+        rescue Raven::Error => e
+          Upfluence.logger.error e.message
+        end
       end
 
       def user=(user)


### PR DESCRIPTION
When event send limitation is exceeded, raven throw an exception which break the soft