### PR TITLE
Support ruby3

### DIFF
--- a/lib/upfluence/http/server.rb
+++ b/lib/upfluence/http/server.rb
@@ -78,7 +78,7 @@ module Upfluence
 
         Thread.new { run_prometheus_exporter } if @options[:push_gateway_url]
 
-        @handler.run(@builder, @options) do |server|
+        @handler.run(@builder, **@options) do |server|
           server.threaded = @options[:threaded] if server.respond_to? :threaded=
 
           if server.respond_to?(:threadpool_size=) && @options[:threadpool_size]

--- a/rbutils.gemspec
+++ b/rbutils.gemspec
@@ -15,10 +15,11 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", ">= 12.3.3"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", ">= 2.2"
+  spec.add_development_dependency "rake", ">= 13.0.0"
+  spec.add_development_dependency "rspec", ">= 3.10"
   spec.add_runtime_dependency 'upfluence-thrift'
   spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'redis'


### PR DESCRIPTION
### What does this PR do?

This PR fixes an  non ruby3 compatible syntax in that lib.
It also updates the gemspec to enforce more realistic minimal dependencies versions.