### PR TITLE
upfluence/error_logger/sentry: Migrate the implementation to use sentry-ruby

### DIFF
--- a/lib/upfluence/error_logger/null.rb
+++ b/lib/upfluence/error_logger/null.rb
@@ -18,7 +18,7 @@ module Upfluence
         end
       end
 
-      def notify(error, _method, *_args)
+      def notify(error, *_args)
         Upfluence.logger.error(error.inspect)
       end
 

--- a/lib/upfluence/error_logger/sentry.rb
+++ b/lib/upfluence/error_logger/sentry.rb
@@ -1,66 +1,107 @@
-require 'raven'
+require 'sentry-ruby'
 
 module Upfluence
   module ErrorLogger
     class Sentry
-      EXCLUDED_ERRORS = (Raven::Configuration::IGNORE_DEFAULT + ['Identity::Thrift::Forbidden'])
+      EXCLUDED_ERRORS = (::Sentry::Configuration::IGNORE_DEFAULT + ['Identity::Thrift::Forbidden'])
+      MAX_TAG_SIZE = 8 * 1024
 
       def initialize
-        ::Raven.configure do |config|
+        @tag_extractors = []
+
+        ::Sentry.init do |config|
+          config.send_default_pii = true
           config.dsn = ENV['SENTRY_DSN']
-          config.current_environment = Upfluence.env
+          config.environment = Upfluence.env
           config.excluded_exceptions = EXCLUDED_ERRORS
           config.logger = Upfluence.logger
           config.release = "#{ENV['PROJECT_NAME']}-#{ENV['SEMVER_VERSION']}"
-          config.tags = {
-            unit_name: unit_name,
-            unit_type: unit_type
-          }.select { |_, v| !v.nil? }
+          config.enable_tracing = false
+          config.auto_session_tracking = false
+        end
+
+        ::Sentry.set_tags(
+          { unit_name: unit_name, unit_type: unit_type }.select { |_, v| v }
+        )
+
+        ::Sentry.with_scope do |scope|
+          scope.add_event_processor do |event, _hint|
+            tags = @tag_extractors.map(&:extract).compact.reduce({}, &:merge)
+
+            tx_name = transaction_name(tags)
+
+            event.transaction = tx_name if tx_name
+            event.extra.merge!(prepare_extra(tags))
+
+            event
+          end
         end
       end
 
-      def notify(error, method, *args)
-        begin
-          Raven.capture_exception(
-            error,
-            extra: { method: method, arguments: args.map(&:inspect) },
-            tags: { method: method }
-          )
-        rescue Raven::Error => e
-          Upfluence.logger.error e.message
+      def append_tag_extractors(klass)
+        @tag_extractors << klass
+      end
+
+      def notify(error, *args)
+        ::Sentry.with_scope do |scope|
+          context = args.reduce({}) do |acc, arg|
+            v = arg.is_a?(Hash) ? arg : { "arg_#{acc.length}" => arg.inspect }
+
+            acc.merge(v)
+          end
+
+          scope.set_extras(prepare_extra(context))
+
+          ::Sentry.capture_exception(error)
         end
+      rescue ::Sentry::Error => e
+        Upfluence.logger.warning e.message
       end
 
       def user=(user)
-        Raven.user_context(id: user.id, email: user.email)
+        ::Sentry.set_user(id: user.id, email: user.email)
       end
 
       def middleware
-        ::Raven::Rack
+        ::Sentry::Rack::CaptureExceptions
       end
 
       def ignore_exception(*klss)
         klss.each do |kls|
-          puts kls
           case kls.class
           when Class
-            Raven.configuration.excluded_exceptions << kls.name
+            ::Sentry.configuration.excluded_exceptions << kls.name
           when String
-            Raven.configuration.excluded_exceptions << kls
+            ::Sentry.configuration.excluded_exceptions << kls
           else
-            Upfluence.logger.warn e.message
+            Upfluence.logger.warn "Unexcepted argument for ignore_exception #{kls}"
           end
         end
       end
 
       private
 
+      def prepare_extra(tags)
+        tags.select { |_k, v| v.respond_to?(:size) && v.size < MAX_TAG_SIZE }
+      end
+
+      def transaction_name(tags)
+        return tags['transaction'] if tags['transaction']
+
+        svc = tags['thrift.request.service']
+        mth = tags['thrift.request.method']
+
+        return "#{svc}##{mth}" if svc && mth
+
+        nil
+      end
+
       def unit_name
-        ENV['UNIT_NAME'].split('.').first if ENV['UNIT_NAME']
+        ENV['UNIT_NAME']&.split('.')&.first
       end
 
       def unit_type
-        unit_name.split('@').first if unit_name
+        unit_name&.split('@')&.first
       end
     end
   end

--- a/rbutils.gemspec
+++ b/rbutils.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'upfluence-thrift'
   spec.add_runtime_dependency 'sinatra'
   spec.add_runtime_dependency 'redis'
-  spec.add_runtime_dependency 'sentry-raven'
+  spec.add_runtime_dependency 'sentry-ruby'
   spec.add_runtime_dependency 'sinatra-contrib'
   spec.add_runtime_dependency 'activesupport'
   spec.add_runtime_dependency 'puma'


### PR DESCRIPTION
### What does this PR do?

This PR, upgrade the sdk we are using to forward exceptions to sentry without breaking our API.

It also adds a concept of TagExtractor that allows you to pass  information in the current thread and retreive them while building the error report.

It is similar to what we have for context extractor in Go.

Also if the method `#tags` is implemented on the exceptions the values will be extracted.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
