### PR TITLE
upfluence/errror_logger/sentry: Ignore sentry error reporting in case of rack exception

### DIFF
--- a/lib/upfluence/http/endpoint/api_endpoint.rb
+++ b/lib/upfluence/http/endpoint/api_endpoint.rb
@@ -88,6 +88,12 @@ module Upfluence
             data
           end
         end
+
+        class << self
+          def error(*codes, &block)
+            Sinatra::Base.error(*codes, &block)
+          end
+        end
       end
 
       Sinatra::Base.error BadRequest do


### PR DESCRIPTION
### What does this PR do?

Related to https://linear.app/upfluence/issue/DRA-2228/%5Bidentity-server%5D-silence-apiexceptioninvalidtokenerror#comment-cbbc3bc3

This PR is here to quiet the errors that are handled by the Sinatra error flow. It will avoid all those noisy error reporting that don't bring much value.


### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
