### PR TITLE
upfluence/instrumentation: Add prometheus tracking for key contention points of our software stack

### DIFF
--- a/lib/upfluence/instrumentation.rb
+++ b/lib/upfluence/instrumentation.rb
@@ -1,0 +1,3 @@
+require 'upfluence/instrumentation/puma_instrumenter'
+require 'upfluence/instrumentation/gc_instrumenter'
+require 'upfluence/instrumentation/active_record_pool_instrumenter'

--- a/lib/upfluence/instrumentation/active_record_pool_instrumenter.rb
+++ b/lib/upfluence/instrumentation/active_record_pool_instrumenter.rb
@@ -1,0 +1,30 @@
+require 'upfluence/instrumentation/periodic_instrumenter'
+require 'active_record'
+
+module Upfluence
+  module Instrumentation
+    class ActiveRecordPoolInstrumenter < PeriodicInstrumenter
+      KEYS = %i[
+        size connections busy dead idle waiting
+      ].freeze
+
+      def prefix
+        'active_record_pool'
+      end
+
+      def metrics
+        KEYS.reduce({}) do |acc, k|
+          acc.merge(k => { docstring: "Gauge for #{k}" })
+        end
+      end
+
+      def values
+        return {} unless ActiveRecord::Base.connected?
+
+        ActiveRecord::Base.connection_pool.stat.slice(*KEYS).reduce({}) do |acc, (k, v)|
+          acc.merge(k => [{ value: v }])
+        end
+      end
+    end
+  end
+end

--- a/lib/upfluence/instrumentation/gc_instrumenter.rb
+++ b/lib/upfluence/instrumentation/gc_instrumenter.rb
@@ -1,0 +1,28 @@
+require 'upfluence/instrumentation/periodic_instrumenter'
+
+module Upfluence
+  module Instrumentation
+    class GCInstrumenter < PeriodicInstrumenter
+      KEYS = %i[
+        heap_live_slots heap_free_slots major_gc_count minor_gc_count
+        total_allocated_objects
+      ].freeze
+
+      def prefix
+        'ruby_gc'
+      end
+
+      def metrics
+        KEYS.reduce({}) do |acc, k|
+          acc.merge(k => { docstring: "Gauge for #{k}" })
+        end
+      end
+
+      def values
+        GC.stat.slice(*KEYS).reduce({}) do |acc, (k, v)|
+          acc.merge(k => [{ value: v }])
+        end
+      end
+    end
+  end
+end

--- a/lib/upfluence/instrumentation/periodic_instrumenter.rb
+++ b/lib/upfluence/instrumentation/periodic_instrumenter.rb
@@ -1,0 +1,61 @@
+module Upfluence
+  module Instrumentation
+    class PeriodicInstrumenter
+      def initialize(interval: 30, registry: ::Prometheus::Client.registry)
+        @interval = interval
+        @gauges = metrics.reduce({}) do |acc, (metric, values)|
+          metric_name = [prefix, metric].compact.join("_").to_sym
+
+          acc.merge(
+            metric => registry.get(metric_name) || registry.gauge(
+              metric_name,
+              docstring: values[:docstring] || '',
+              labels:    values[:labels] || []
+            )
+          )
+        end
+
+        @stop_thread = false
+      end
+
+      def start
+        @thread ||= Thread.new do
+          until @stop_thread
+            begin
+              values.each do |(metric, vs)|
+                vs.each do |v|
+                  @gauges[metric].set(v[:value], labels: v[:labels] || {})
+                end
+              end
+            rescue => e
+              Upfluence.error_logger.notify(e)
+            ensure
+              sleep @interval
+            end
+          end
+        end
+      end
+
+      def stop
+        return unless @thread&.alive?
+
+        @stop_thread = true
+        @thread.wakeup
+        @thread.join
+        @thread = nil
+      end
+
+      def prefix
+        nil
+      end
+
+      def values
+        raise "Please implement a subcalss"
+      end
+
+      def metrics
+        raise "Please implement a subcalss"
+      end
+    end
+  end
+end

--- a/lib/upfluence/instrumentation/puma_instrumenter.rb
+++ b/lib/upfluence/instrumentation/puma_instrumenter.rb
@@ -1,0 +1,33 @@
+require 'upfluence/instrumentation/periodic_instrumenter'
+require 'puma'
+
+module Upfluence
+  module Instrumentation
+    class PumaInstrumenter < PeriodicInstrumenter
+      KEYS = %i[backlog_thread running_thread pool_capacity requests_count].freeze
+
+      def prefix
+        'puma'
+      end
+
+      def metrics
+        KEYS.reduce({}) do |acc, k|
+          acc.merge(k => { docstring: "Gauge for #{k}" })
+        end
+      end
+
+      def values
+        stats = Puma.stats_hash
+
+        {
+          requests_count: [{ value: stats[:requests_count] }],
+          backlog_thread: [{ value: stats[:backlog] }],
+          running_thread: [{ value: stats[:running] }],
+          pool_capacity:  [{ value: stats[:pool_capacity] }]
+        }
+      rescue NoMethodError
+        {}
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to push our instrumentation level in order to find potential sources of slow downs.

Mostly pool contention at the http server (puma) or active record connection pool level.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
