### PR TITLE
feat(lib/upfluence/error_logger/sentry.rb): tag errors as warning based on exception class name or message

### DIFF
--- a/lib/upfluence/error_logger/sentry.rb
+++ b/lib/upfluence/error_logger/sentry.rb
@@ -156,7 +156,7 @@ module Upfluence
 
         lowercased_message = error.message.downcase
         WARNING_LEVEL_EXCEPTION_MESSAGES.each do |msg|
-          scope.set_level :warning if lowercased_message.include?(msg)
+          scope.set_level :warning if lowercased_message.include?(msg.downcase)
         end
       end
     end

--- a/lib/upfluence/error_logger/sentry.rb
+++ b/lib/upfluence/error_logger/sentry.rb
@@ -172,6 +172,8 @@ module Upfluence
       end
 
       def set_error_level(event, error)
+        return :error if error.nil?
+
         @level_procs.each do |lvp|
           level = lvp.call(error)
 
@@ -181,6 +183,8 @@ module Upfluence
 
           break
         end
+
+        :error
       end
     end
   end

--- a/lib/upfluence/error_logger/sentry.rb
+++ b/lib/upfluence/error_logger/sentry.rb
@@ -13,33 +13,33 @@ module Upfluence
       )
 
       class << self
-        def err_name_lambda(level, name)
-          lambda do |err|
-            level if err.class.name == name
+        def exception_name_lambda(level, name)
+          lambda do |exception|
+            level if exception.class.name.eql? name
           end
         end
 
-        def err_message_lambda(level, message)
+        def exception_message_lambda(level, message)
           downcased_message = message.downcase
 
-          lambda do |err|
-            level if err.message.downcase.include?(downcased_message)
+          lambda do |exception|
+            level if exception.message.downcase.include?(downcased_message)
           end
         end
       end
 
       DEFAULT_LEVEL_PROCS = [
-        err_name_lambda(:warning, 'Net::ReadTimeout'),
-        err_name_lambda(:warning, 'EOFError'),
-        err_name_lambda(:warning, 'ActiveRecord::QueryCanceled'),
-        err_name_lambda(:warning, 'Timeout::Error'),
-        err_name_lambda(:warning, 'Errno::ECONNRESET'),
-        err_name_lambda(:warning, 'OAuth2::ConnectionError'),
-        err_message_lambda(:warning, 'Connection reset by peer'),
-        err_message_lambda(:warning, 'Connection refused'),
-        err_message_lambda(:warning, 'connection refused'),
-        err_message_lambda(:warning, 'Failed to open TCP connection'),
-        err_message_lambda(:warning, 'Net::ReadTimeout')
+        exception_name_lambda(:warning, 'Net::ReadTimeout'),
+        exception_name_lambda(:warning, 'EOFError'),
+        exception_name_lambda(:warning, 'ActiveRecord::QueryCanceled'),
+        exception_name_lambda(:warning, 'Timeout::Error'),
+        exception_name_lambda(:warning, 'Errno::ECONNRESET'),
+        exception_name_lambda(:warning, 'OAuth2::ConnectionError'),
+        exception_message_lambda(:warning, 'Connection reset by peer'),
+        exception_message_lambda(:warning, 'Connection refused'),
+        exception_message_lambda(:warning, 'connection refused'),
+        exception_message_lambda(:warning, 'Failed to open TCP connection'),
+        exception_message_lambda(:warning, 'Net::ReadTimeout')
       ].freeze
       MAX_TAG_SIZE = 8 * 1024
 
@@ -75,7 +75,7 @@ module Upfluence
             event.transaction = tx_name if tx_name
             event.extra.merge!(prepare_extra(tags))
 
-            set_error_level(event, exc)
+            event.level = compute_exception_level(exc)
 
             event
           end
@@ -86,8 +86,8 @@ module Upfluence
         @tag_extractors << klass
       end
 
-      # proc must accept an error and return either a sentry level (:error, :warning, etc.)
-      # or nil if the error is not matched
+      # proc must accept an exception and return either a sentry level (:error, :warning, etc.)
+      # or nil if the exception is not matched
       def append_level_procs(proc)
         @level_procs << proc
       end
@@ -171,17 +171,15 @@ module Upfluence
         unit_name&.split('@')&.first
       end
 
-      def set_error_level(event, error)
-        return :error if error.nil?
+      def compute_exception_level(exception)
+        return :error if exception.nil?
 
         @level_procs.each do |lvp|
-          level = lvp.call(error)
+          level = lvp.call(exception)
 
           next if level.nil?
 
-          event.level = level
-
-          break
+          return level
         end
 
         :error

--- a/lib/upfluence/error_logger/sentry.rb
+++ b/lib/upfluence/error_logger/sentry.rb
@@ -11,25 +11,41 @@ module Upfluence
           'ActiveRecord::ConcurrentMigrationError'
         ]
       )
-      WARNING_LEVEL_KLASS_NAMES = [
-        'Net::ReadTimeout',
-        'EOFError',
-        'ActiveRecord::QueryCanceled',
-        'Timeout::Error',
-        'Errno::ECONNRESET',
-        'OAuth2::ConnectionError'
-      ].freeze
-      WARNING_LEVEL_EXCEPTION_MESSAGES = [
-        'Connection reset by peer',
-        'Connection refused',
-        'connection refused',
-        'Failed to open TCP connection',
-        'Net::ReadTimeout'
+
+      class << self
+        def err_name_lambda(level, name)
+          lambda do |err|
+            level if err.class.name == name
+          end
+        end
+
+        def err_message_lambda(level, message)
+          downcased_message = message.downcase
+
+          lambda do |err|
+            level if err.message.downcase.include?(downcased_message)
+          end
+        end
+      end
+
+      DEFAULT_LEVEL_PROCS = [
+        err_name_lambda(:warning, 'Net::ReadTimeout'),
+        err_name_lambda(:warning, 'EOFError'),
+        err_name_lambda(:warning, 'ActiveRecord::QueryCanceled'),
+        err_name_lambda(:warning, 'Timeout::Error'),
+        err_name_lambda(:warning, 'Errno::ECONNRESET'),
+        err_name_lambda(:warning, 'OAuth2::ConnectionError'),
+        err_message_lambda(:warning, 'Connection reset by peer'),
+        err_message_lambda(:warning, 'Connection refused'),
+        err_message_lambda(:warning, 'connection refused'),
+        err_message_lambda(:warning, 'Failed to open TCP connection'),
+        err_message_lambda(:warning, 'Net::ReadTimeout')
       ].freeze
       MAX_TAG_SIZE = 8 * 1024
 
       def initialize
         @tag_extractors = []
+        @level_procs = [*DEFAULT_LEVEL_PROCS]
 
         ::Sentry.init do |config|
           config.send_default_pii = true
@@ -59,6 +75,8 @@ module Upfluence
             event.transaction = tx_name if tx_name
             event.extra.merge!(prepare_extra(tags))
 
+            set_error_level(event, exc)
+
             event
           end
         end
@@ -66,6 +84,12 @@ module Upfluence
 
       def append_tag_extractors(klass)
         @tag_extractors << klass
+      end
+
+      # proc must accept an error and return either a sentry level (:error, :warning, etc.)
+      # or nil if the error is not matched
+      def append_level_procs(proc)
+        @level_procs << proc
       end
 
       def notify(error, *args)
@@ -82,7 +106,6 @@ module Upfluence
           end
 
           scope.set_extras(prepare_extra(context))
-          set_error_level(scope, error)
 
           ::Sentry.capture_exception(error)
         end
@@ -148,15 +171,15 @@ module Upfluence
         unit_name&.split('@')&.first
       end
 
-      def set_error_level(scope, error)
-        if WARNING_LEVEL_KLASS_NAMES.include?(error.class.name)
-          scope.set_level :warning
-          return
-        end
+      def set_error_level(event, error)
+        @level_procs.each do |lvp|
+          level = lvp.call(error)
 
-        lowercased_message = error.message.downcase
-        WARNING_LEVEL_EXCEPTION_MESSAGES.each do |msg|
-          scope.set_level :warning if lowercased_message.include?(msg.downcase)
+          next if level.nil?
+
+          event.level = level
+
+          break
         end
       end
     end


### PR DESCRIPTION
### What does this PR do?

- Use a list of class names or exception messages to set the Sentry error level to `:warning` if the raised exception matches
- `:error` is maintained as the default error level in this case

The DI problem is not quited solved here as we do not provide any way for the caller to add extra class names or message strings. this problem is slightly alleviated by the fact that most "noise" ruby errors are already handled by all of these cases, and that we are unlikely to need new ones for now.

If we wanted that problem cleanly solved, we could pass arrays of class names/strings in the constructor (in an object), and either append or replace (based on a flag) but this seems overkill for now.

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces configurable warning-level classification for Sentry events based on exception class names and messages.
> 
> - Adds `exception_name_lambda`/`exception_message_lambda` and `DEFAULT_LEVEL_PROCS`; sets `event.level` via new `compute_exception_level`
> - New `append_level_procs` to allow extending level matchers at runtime
> - Expands `EXCLUDED_ERRORS` with `ActiveRecord::ConcurrentMigrationError`
> - Switches Sentry config to use `sdk_logger` instead of `logger`
> - Refines `RackMiddleware#capture_exception` Sinatra check and calls `super` without args
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d85275365c8e48d1e6adee064dc7f4b84857ca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->