### PR TITLE
upfluence/error_logger/sentry: Stringify extras passed down thru notify

### DIFF
--- a/lib/upfluence/error_logger/sentry.rb
+++ b/lib/upfluence/error_logger/sentry.rb
@@ -96,7 +96,7 @@ module Upfluence
         ::Sentry.with_scope do |scope|
           context = args.reduce({}) do |acc, arg|
             v = if arg.is_a?(Hash)
-                  arg
+                  arg.transform_keys(&:to_s).transform_values(&:inspect)
                 else
                   key = acc.empty? ? 'method' : "arg_#{acc.length}"
                   { key => arg.inspect }


### PR DESCRIPTION
### What does this PR do?

We see `Event capturing failed: {} is not a symbol nor a string` in our logs sometimes. I think it comes from `extra` being passed with keys being non string or a symbol. This patch should solve that.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
